### PR TITLE
Upgrade wildfly-maven-plugin 4.0.0.Alpha2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <version.org.jboss.logging.jboss-logging>3.4.3.Final-redhat-00001</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logmanager.jboss-logmanager>2.1.18.Final-redhat-00001</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.staxmapper>1.3.0.Final-redhat-1</version.org.jboss.staxmapper>
-        <version.org.wildfly.maven.plugin>4.0.0.Alpha1</version.org.wildfly.maven.plugin>
+        <version.org.wildfly.maven.plugin>4.0.0.Alpha2</version.org.wildfly.maven.plugin>
     </properties>
     
     <dependencyManagement>


### PR DESCRIPTION
Dev tag:
https://github.com/wildfly/wildfly-maven-plugin/releases/tag/4.0.0.Alpha2
Diff to previously integrated release:
https://github.com/wildfly/wildfly-maven-plugin/compare/4.0.0.Alpha1...4.0.0.Alpha2

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>