### PR TITLE
Exclude commons-lang3, slf4j-api from maven & galleon dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,10 @@
                         <groupId>org.apache.commons</groupId>
                         <artifactId>commons-lang3</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -448,6 +452,12 @@
                 <groupId>org.jboss.galleon</groupId>
                 <artifactId>galleon-core</artifactId>
                 <version>${version.org.jboss.galleon}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,12 @@
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-core</artifactId>
                 <version>${version.org.apache.maven.maven-core}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
@jfdenise would such a change belong here or into the upstream wildfly-maven-plugin?

This makes it easier to align the project by automated tooling.