### PR TITLE
[CONVERSION COMMIT] Add maven-resolver-util as dependency, required when auth enabled in maven repos

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -155,6 +155,10 @@
             <artifactId>maven-resolver</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-util</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.prospero</groupId>
             <artifactId>prospero-metadata</artifactId>
         </dependency>


### PR DESCRIPTION
This is not required in WildFly Maven plugin, this dependency comes transitively.