### PR TITLE
Fix for JBEAP-33366, Bootable JAR filename has double dash: server--bootable.jar instead of server-bootable.jar

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
@@ -251,7 +251,7 @@ public class PackageServerMojo extends AbstractProvisionServerMojo {
      * @since 5.0
      */
     @Parameter(alias = "bootable-jar-name", property = PropertyNames.BOOTABLE_JAR_NAME, defaultValue = BOOTABLE_JAR_NAME_RADICAL
-            + "-bootable.jar")
+            + "bootable.jar")
     private String bootableJarName;
 
     /**


### PR DESCRIPTION
ISSUE: https://redhat.atlassian.net/browse/JBEAP-33366