### PR TITLE
Fix for JBEAP-33249, eap-maven-plugin creates bootable JAR with wrong name (server--bootable.jar instead of {artifactId}-bootable.jar)

### DIFF
--- a/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
+++ b/plugin/src/main/java/org/wildfly/plugin/provision/PackageServerMojo.java
@@ -250,8 +250,7 @@ public class PackageServerMojo extends AbstractProvisionServerMojo {
      *
      * @since 5.0
      */
-    @Parameter(alias = "bootable-jar-name", property = PropertyNames.BOOTABLE_JAR_NAME, defaultValue = BOOTABLE_JAR_NAME_RADICAL
-            + "bootable.jar")
+    @Parameter(alias = "bootable-jar-name", property = PropertyNames.BOOTABLE_JAR_NAME, defaultValue = "${project.artifactId}-bootable.jar")
     private String bootableJarName;
 
     /**


### PR DESCRIPTION
ISSUE: https://redhat.atlassian.net/browse/JBEAP-33429